### PR TITLE
feat(auth): create basic SignIn screen UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,4 +68,5 @@ dependencies {
     debugImplementation(libs.androidx.ui.test.manifest)
 
     implementation(project(":feature:tasklist"))
+    implementation(project(":feature:auth"))
 }

--- a/app/src/main/java/com/fermer/todox/MainActivity.kt
+++ b/app/src/main/java/com/fermer/todox/MainActivity.kt
@@ -11,7 +11,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.fermer.auth.presentation.screen.SignInScreen
 import com.fermer.tasklist.presentation.TaskListViewModel
+import com.fermer.tasklist.presentation.screen.TaskListScreen
 import com.fermer.todox.ui.theme.TodoXTheme
 
 class MainActivity : ComponentActivity() {
@@ -22,11 +24,14 @@ class MainActivity : ComponentActivity() {
 
         enableEdgeToEdge()
         setContent {
+            SignInScreen { email, password ->
+                println("Login clicked: $email / $password")
+            }
 
-         /*   val viewModel = TaskListViewModel()
-            TaskListScreen(viewModel)*/
-
-          /*  TodoXTheme {
+           /* val viewModel = TaskListViewModel()
+            TaskListScreen(viewModel)
+*/
+         /*   TodoXTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     Greeting(
                         name = "Android",

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
 }
 
 android {
@@ -30,6 +31,13 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.3"
+    }
 }
 
 dependencies {
@@ -37,6 +45,11 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.material3)
+    implementation(libs.lifecycle.viewmodel)
+    implementation(libs.androidx.foundation.layout)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/feature/auth/src/main/java/com/fermer/auth/presentation/AuthViewModel.kt
+++ b/feature/auth/src/main/java/com/fermer/auth/presentation/AuthViewModel.kt
@@ -1,0 +1,3 @@
+package com.fermer.auth.presentation
+
+

--- a/feature/auth/src/main/java/com/fermer/auth/presentation/model/AuthUiState.kt
+++ b/feature/auth/src/main/java/com/fermer/auth/presentation/model/AuthUiState.kt
@@ -1,0 +1,2 @@
+package com.fermer.auth.presentation.model
+

--- a/feature/auth/src/main/java/com/fermer/auth/presentation/screen/SignInScreen.kt
+++ b/feature/auth/src/main/java/com/fermer/auth/presentation/screen/SignInScreen.kt
@@ -1,0 +1,54 @@
+package com.fermer.auth.presentation.screen
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SignInScreen(
+    onSignInClick: (email: String, password: String) -> Unit
+) {
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Sign In", style = MaterialTheme.typography.headlineMedium)
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        OutlinedTextField(
+            value = email,
+            onValueChange = { email = it },
+            label = { Text("Email") },
+            singleLine = true
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Password") },
+            singleLine = true,
+            visualTransformation = PasswordVisualTransformation()
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Button(
+            onClick = { onSignInClick(email, password) },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Login")
+        }
+    }
+}

--- a/feature/tasklist/build.gradle.kts
+++ b/feature/tasklist/build.gradle.kts
@@ -48,11 +48,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
-
     implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling)
     implementation(libs.androidx.material3)
     implementation(libs.lifecycle.viewmodel)
     implementation(libs.androidx.foundation.layout)

--- a/feature/tasklist/src/main/java/com/fermer/tasklist/presentation/screen/TaskListScreen.kt
+++ b/feature/tasklist/src/main/java/com/fermer/tasklist/presentation/screen/TaskListScreen.kt
@@ -1,22 +1,19 @@
 package com.fermer.tasklist.presentation.screen
 
-
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.fillMaxSize
-/*import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.ui.unit.dp*/
+import androidx.compose.ui.unit.dp
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-
 import com.fermer.tasklist.presentation.TaskListViewModel
 
 
@@ -26,19 +23,17 @@ fun TaskListScreen(viewModel: TaskListViewModel) {
     Box(modifier = Modifier.fillMaxSize()) {
         when {
             uiState.isLoading -> {
-               // CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
             }
+
             uiState.error != null -> {
-                /*Text(
+                Text(
                     text = "Error: ${uiState.error}",
                     color = MaterialTheme.colorScheme.error,
                     modifier = Modifier.align(Alignment.Center)
-                )*/
+                )
             }
-            }
-        }
 
-/*
             else -> {
                 LazyColumn(
                     modifier = Modifier
@@ -55,5 +50,7 @@ fun TaskListScreen(viewModel: TaskListViewModel) {
                 }
             }
         }
-    }*/
+    }
 }
+
+


### PR DESCRIPTION
### 📌 Summary

This PR adds the initial implementation of the SignIn screen UI using Jetpack Compose.  
It includes two input fields (email, password) and a login button.  
Currently, no Firebase logic is connected — this will be added in the next tasks.

---

### ✅ Changes

- Created `SignInScreen.kt` under `feature-auth/presentation/screen`
- Implemented basic layout with email/password inputs and login button
- Connected click listener with callback
- Previewed the screen in MainActivity (temporary)

---

### 📎 Related Task

Sprint 1 > Day 2 > Task 4: SignIn UI screen

---

### 🚧 Notes

- No error handling or loading state yet (planned in upcoming tasks)
- ViewModel will be added in Task 6

