### PR TITLE
feat(task): complete TaskList feature with add and swipe-to-delete

### DIFF
--- a/feature/task/src/main/java/com/fermer/task/presentation/TaskListRoute.kt
+++ b/feature/task/src/main/java/com/fermer/task/presentation/TaskListRoute.kt
@@ -1,0 +1,18 @@
+package com.fermer.task.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun TaskListRoute(viewModel: TaskViewModel = hiltViewModel()) {
+
+    val tasks by viewModel.tasks.collectAsState()
+
+    TaskListScreen(
+        taskList = tasks,
+        onAddTask = { viewModel.addTask(it) },
+        onRemoveTask = { viewModel.removeTask(it) }
+    )
+}

--- a/feature/task/src/main/java/com/fermer/task/presentation/TaskListScreen.kt
+++ b/feature/task/src/main/java/com/fermer/task/presentation/TaskListScreen.kt
@@ -1,13 +1,15 @@
 package com.fermer.task.presentation
 
-
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.fermer.model.TaskModel
+import com.fermer.task.presentation.components.TaskItem
+
 @Composable
 fun TaskListScreen(
     taskList: List<TaskModel>,
@@ -32,25 +34,16 @@ fun TaskListScreen(
             if (taskList.isEmpty()) {
                 Text("No tasks yet")
             } else {
-                taskList.forEach { task ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp)
-                            .clickable { onRemoveTask(task.id) }
-                    ) {
-                        Text(
-                            text = task.title,
-                            modifier = Modifier.weight(1f)
-                        )
-                        Text(
-                            text = if (task.isDone) "✅" else "❌"
+                LazyColumn {
+                    items(taskList, key = { it.id }) { task ->
+                        TaskItem(
+                            task = task,
+                            onRemove = onRemoveTask
                         )
                     }
                 }
             }
         }
-
 
         if (showDialog) {
             AlertDialog(
@@ -84,3 +77,4 @@ fun TaskListScreen(
         }
     }
 }
+

--- a/feature/task/src/main/java/com/fermer/task/presentation/TaskListScreen.kt
+++ b/feature/task/src/main/java/com/fermer/task/presentation/TaskListScreen.kt
@@ -8,16 +8,18 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.fermer.model.TaskModel
-
 @Composable
 fun TaskListScreen(
     taskList: List<TaskModel>,
-    onAddTaskClicked: () -> Unit,
+    onAddTask: (String) -> Unit,
     onRemoveTask: (String) -> Unit
 ) {
+    var showDialog by remember { mutableStateOf(false) }
+    var newTaskTitle by remember { mutableStateOf("") }
+
     Scaffold(
         floatingActionButton = {
-            FloatingActionButton(onClick = onAddTaskClicked) {
+            FloatingActionButton(onClick = { showDialog = true }) {
                 Text("+")
             }
         }
@@ -47,6 +49,38 @@ fun TaskListScreen(
                     }
                 }
             }
+        }
+
+
+        if (showDialog) {
+            AlertDialog(
+                onDismissRequest = { showDialog = false },
+                confirmButton = {
+                    Button(onClick = {
+                        onAddTask(newTaskTitle)
+                        newTaskTitle = ""
+                        showDialog = false
+                    }) {
+                        Text("Add")
+                    }
+                },
+                dismissButton = {
+                    OutlinedButton(onClick = {
+                        showDialog = false
+                    }) {
+                        Text("Cancel")
+                    }
+                },
+                title = { Text("Add New Task") },
+                text = {
+                    OutlinedTextField(
+                        value = newTaskTitle,
+                        onValueChange = { newTaskTitle = it },
+                        label = { Text("Task Title") },
+                        singleLine = true
+                    )
+                }
+            )
         }
     }
 }

--- a/feature/task/src/main/java/com/fermer/task/presentation/components/TaskItem.kt
+++ b/feature/task/src/main/java/com/fermer/task/presentation/components/TaskItem.kt
@@ -1,0 +1,73 @@
+package com.fermer.task.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.fermer.model.TaskModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TaskItem(
+    task: TaskModel,
+    onRemove: (String) -> Unit
+) {
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { value ->
+            if (value == SwipeToDismissBoxValue.EndToStart) {
+                onRemove(task.id)
+                true
+            } else false
+        }
+    )
+
+    SwipeToDismissBox(
+        state = dismissState,
+        backgroundContent = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Red)
+                    .padding(horizontal = 16.dp),
+                contentAlignment = Alignment.CenterEnd
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = "Delete task",
+                    tint = Color.White
+                )
+            }
+        }
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 4.dp),
+            shape = RoundedCornerShape(8.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = task.title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.weight(1f)
+                )
+                if (task.isDone) {
+                    Text(text = "✅")
+                }
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3Android" }
 lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }


### PR DESCRIPTION
This PR completes the TaskList feature with full support for displaying, adding, and removing tasks:

-  Implemented TaskListScreen with Jetpack Compose
-  Add task via Dialog with text input
-  Remove task using SwipeToDismiss gesture (Material3)
-  ViewModel integration with FakeRepository using Kotlin Flow
-  Modular structure in feature-task module
-  Connected to shared TaskModel across modules

Next step: Add ViewModel unit test (Day 3 - Task 7)
