### PR TITLE
feat(ui): implement TaskScreen with Compose and integrate with TaskViewModel

### DIFF
--- a/feature/task/src/main/java/com/fermer/task/di/TaskModule.kt
+++ b/feature/task/src/main/java/com/fermer/task/di/TaskModule.kt
@@ -12,9 +12,9 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 abstract class TaskModule {
 
-    @Binds
+    /*@Binds
     @Singleton
     abstract fun bindTaskRepository(
         fakeTaskRepository: FakeTaskRepository
-    ): TaskRepository
+    ): TaskRepository*/
 }

--- a/feature/task/src/main/java/com/fermer/task/presentation/TaskScreen.kt
+++ b/feature/task/src/main/java/com/fermer/task/presentation/TaskScreen.kt
@@ -1,0 +1,56 @@
+package com.fermer.task.presentation
+
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.fermer.task.presentation.components.TaskItem
+
+@Composable
+fun TaskScreen(
+    viewModel: TaskViewModel = hiltViewModel()
+) {
+    val tasks by viewModel.tasks.collectAsState()
+    var newTaskTitle by remember { mutableStateOf("") }
+
+    Column(modifier = Modifier.padding(16.dp)) {
+
+        Row(modifier = Modifier.fillMaxWidth()) {
+            OutlinedTextField(
+                value = newTaskTitle,
+                onValueChange = { newTaskTitle = it },
+                label = { Text("New Task") },
+                modifier = Modifier.weight(1f)
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Button(
+                onClick = {
+                    if (newTaskTitle.isNotBlank()) {
+                        viewModel.addTask(newTaskTitle)
+                        newTaskTitle = ""
+                    }
+                }
+            ) {
+                Text("Add")
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        LazyColumn {
+            items(tasks) { task ->
+                TaskItem(
+                    task = task,
+                    onDelete = { viewModel.removeTask(task.id) }
+                )
+            }
+        }
+    }
+}

--- a/feature/task/src/main/java/com/fermer/task/presentation/components/TaskItem.kt
+++ b/feature/task/src/main/java/com/fermer/task/presentation/components/TaskItem.kt
@@ -13,61 +13,30 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.fermer.model.TaskModel
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.ui.unit.dp
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TaskItem(
     task: TaskModel,
-    onRemove: (String) -> Unit
+    onDelete: () -> Unit
 ) {
-    val dismissState = rememberSwipeToDismissBoxState(
-        confirmValueChange = { value ->
-            if (value == SwipeToDismissBoxValue.EndToStart) {
-                onRemove(task.id)
-                true
-            } else false
-        }
-    )
-
-    SwipeToDismissBox(
-        state = dismissState,
-        backgroundContent = {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.Red)
-                    .padding(horizontal = 16.dp),
-                contentAlignment = Alignment.CenterEnd
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Delete,
-                    contentDescription = "Delete task",
-                    tint = Color.White
-                )
-            }
-        }
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
     ) {
-        Card(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 4.dp),
-            shape = RoundedCornerShape(8.dp)
+        Row(modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = task.title,
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.weight(1f)
-                )
-                if (task.isDone) {
-                    Text(text = "✅")
-                }
+            Text(text = task.title)
+            IconButton(onClick = onDelete) {
+                Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete")
             }
         }
     }
 }
+


### PR DESCRIPTION
This PR adds the initial UI screen for task management using Jetpack Compose:

🔹 TaskScreen.kt:
- Displays a list of current tasks from TaskViewModel (via Firebase).
- Allows users to add a new task using a text field and a button.
- Supports task deletion via a Delete icon button.

🔹 TaskItem.kt:
- A composable card representing each task, with title and delete action.

📦 Connected to real TaskViewModel using Hilt and StateFlow.

✅ Manually tested on emulator: task creation and deletion are working as expected.

This completes Task 4 of Sprint 1 - Day 4.
