### PR TITLE
feat(nav): add app NavHost (Splash → Auth → Tasks), presentational auth screens, and MainActivity wiring

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,9 @@ dependencies {
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)
 
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.hilt.navigation.compose)
+
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/fermer/todox/MainActivity.kt
+++ b/app/src/main/java/com/fermer/todox/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.fermer.task.presentation.TaskListRoute
+import com.fermer.todox.nav.AppNavHost
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -19,7 +20,7 @@ class MainActivity : ComponentActivity() {
         setContent {
 
 
-            TaskListRoute()
+            AppNavHost()
 
 
         }

--- a/app/src/main/java/com/fermer/todox/nav/AppDestinations.kt
+++ b/app/src/main/java/com/fermer/todox/nav/AppDestinations.kt
@@ -1,0 +1,8 @@
+package com.fermer.todox.nav
+
+sealed class Dest(val route: String) {
+    object Splash : Dest("splash")
+    object SignIn : Dest("auth/signin")
+    object SignUp : Dest("auth/signup")
+    object Tasks  : Dest("tasks")
+}

--- a/app/src/main/java/com/fermer/todox/nav/AppNavHost.kt
+++ b/app/src/main/java/com/fermer/todox/nav/AppNavHost.kt
@@ -1,0 +1,75 @@
+package com.fermer.todox.nav
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.fermer.task.presentation.TaskScreen
+import com.google.firebase.auth.FirebaseAuth
+
+@Composable
+fun AppNavHost(
+    navController: NavHostController = rememberNavController()
+) {
+    NavHost(navController = navController, startDestination = Dest.Splash.route) {
+
+        composable(Dest.Splash.route) {
+
+            val isLoggedIn = FirebaseAuth.getInstance().currentUser != null
+            LaunchedEffect(isLoggedIn) {
+                navController.navigate(
+                    if (isLoggedIn)
+                        Dest.Tasks.route
+                    else
+                        Dest.SignIn.route)
+                {
+                    popUpTo(Dest.Splash.route) { inclusive = true }
+                    launchSingleTop = true
+                }
+            }
+
+            BoxedLoading()
+        }
+
+        composable(Dest.SignIn.route) {
+
+            SignInRoute(
+                onNavigateToSignUp = { navController.navigate(Dest.SignUp.route) },
+                onAuthSuccess = {
+                    navController.navigate(Dest.Tasks.route) {
+                        popUpTo(Dest.SignIn.route) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                }
+            )
+        }
+
+        composable(Dest.SignUp.route) {
+            SignUpRoute(
+                onNavigateToSignIn = { navController.popBackStack() },
+                onAuthSuccess = {
+                    navController.navigate(Dest.Tasks.route) {
+                        popUpTo(Dest.SignUp.route) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                }
+            )
+        }
+
+
+        composable(Dest.Tasks.route) {
+            TaskScreen()
+        }
+    }
+}
+
+@Composable
+private fun BoxedLoading() {
+    Scaffold { padding ->
+        CircularProgressIndicator(modifier = androidx.compose.ui.Modifier.padding(padding)) }
+}

--- a/app/src/main/java/com/fermer/todox/nav/AuthRoutes.kt
+++ b/app/src/main/java/com/fermer/todox/nav/AuthRoutes.kt
@@ -1,0 +1,51 @@
+package com.fermer.todox.nav
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.fermer.auth.presentation.AuthViewModel
+import com.fermer.auth.presentation.screen.SignInScreen
+import com.fermer.auth.presentation.screen.SignUpScreen
+
+@Composable
+fun SignInRoute(
+    onNavigateToSignUp: () -> Unit,
+    onAuthSuccess: () -> Unit,
+    viewModel: AuthViewModel = hiltViewModel()
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(state.isSuccess) {
+        if (state.isSuccess) onAuthSuccess()
+    }
+
+    SignInScreen(
+        isLoading = state.isLoading,
+        error = state.errorMessage,
+        onSignInClick = { email, pass -> viewModel.signIn(email, pass) },
+        onNavigateToSignUp = onNavigateToSignUp
+    )
+}
+
+@Composable
+fun SignUpRoute(
+    onNavigateToSignIn: () -> Unit,
+    onAuthSuccess: () -> Unit,
+    viewModel: AuthViewModel = hiltViewModel()
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(state.isSuccess) {
+        if (state.isSuccess) onAuthSuccess()
+    }
+
+    SignUpScreen(
+        isLoading = state.isLoading,
+        error = state.errorMessage,
+        onSignUpClick = { email, pass -> viewModel.signUp(email, pass) },
+        onNavigateToSignIn = onNavigateToSignIn
+    )
+}
+

--- a/feature/auth/src/main/java/com/fermer/auth/presentation/screen/SignInScreen.kt
+++ b/feature/auth/src/main/java/com/fermer/auth/presentation/screen/SignInScreen.kt
@@ -9,15 +9,13 @@ import androidx.compose.ui.unit.dp
 import com.fermer.auth.presentation.AuthViewModel
 @Composable
 fun SignInScreen(
+    isLoading: Boolean,
+    error: String?,
     onSignInClick: (email: String, password: String) -> Unit,
-    /*onNavigateToSignUp: () -> Unit,*/
-
+    onNavigateToSignUp: () -> Unit,
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
-
-    val viewModel: AuthViewModel = remember { AuthViewModel() }
-    val uiState by viewModel.uiState.collectAsState()
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -29,8 +27,7 @@ fun SignInScreen(
         ) {
 
             Text("Sign in to your account", style = MaterialTheme.typography.headlineMedium)
-
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(Modifier.height(24.dp))
 
             OutlinedTextField(
                 value = email,
@@ -39,7 +36,7 @@ fun SignInScreen(
                 modifier = Modifier.fillMaxWidth()
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(Modifier.height(16.dp))
 
             OutlinedTextField(
                 value = password,
@@ -49,38 +46,33 @@ fun SignInScreen(
                 modifier = Modifier.fillMaxWidth()
             )
 
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(Modifier.height(24.dp))
 
             Button(
                 onClick = { onSignInClick(email, password) },
-                enabled = !uiState.isLoading,
+                enabled = !isLoading,
                 modifier = Modifier.fillMaxWidth()
-            ) {
-                Text("Login")
+            ) { Text("Login") }
+
+            Spacer(Modifier.height(8.dp))
+
+            TextButton(onClick = onNavigateToSignUp) {
+                Text("Don't have an account? Sign up")
             }
 
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(Modifier.height(8.dp))
 
-            //TextButton(onClick = onNavigateToSignUp) {
-                Text("Don't have an account? Sign up")
-          //  }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-
-            uiState.errorMessage?.let { error ->
+            error?.let {
                 Text(
-                    text = error,
+                    text = it,
                     color = MaterialTheme.colorScheme.error,
                     style = MaterialTheme.typography.bodySmall
                 )
             }
         }
 
-        if (uiState.isLoading) {
-            CircularProgressIndicator(
-                modifier = Modifier.align(Alignment.Center)
-            )
+        if (isLoading) {
+            CircularProgressIndicator(Modifier.align(Alignment.Center))
         }
     }
 }

--- a/feature/auth/src/main/java/com/fermer/auth/presentation/screen/SignUpScreen.kt
+++ b/feature/auth/src/main/java/com/fermer/auth/presentation/screen/SignUpScreen.kt
@@ -11,15 +11,13 @@ import androidx.compose.ui.unit.dp
 import com.fermer.auth.presentation.AuthViewModel
 @Composable
 fun SignUpScreen(
+    isLoading: Boolean,
+    error: String?,
     onSignUpClick: (email: String, password: String) -> Unit,
-   /* onNavigateToSignIn: () -> Unit,*/
-
+    onNavigateToSignIn: () -> Unit,
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
-
-    val viewModel: AuthViewModel = remember { AuthViewModel() }
-    val uiState by viewModel.uiState.collectAsState()
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -31,8 +29,7 @@ fun SignUpScreen(
         ) {
 
             Text("Create a new account", style = MaterialTheme.typography.headlineMedium)
-
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(Modifier.height(24.dp))
 
             OutlinedTextField(
                 value = email,
@@ -41,7 +38,7 @@ fun SignUpScreen(
                 modifier = Modifier.fillMaxWidth()
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(Modifier.height(16.dp))
 
             OutlinedTextField(
                 value = password,
@@ -51,36 +48,33 @@ fun SignUpScreen(
                 modifier = Modifier.fillMaxWidth()
             )
 
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(Modifier.height(24.dp))
 
             Button(
                 onClick = { onSignUpClick(email, password) },
-                enabled = !uiState.isLoading,
+                enabled = !isLoading,
                 modifier = Modifier.fillMaxWidth()
-            ) {
-                Text("Register")
+            ) { Text("Register") }
+
+            Spacer(Modifier.height(8.dp))
+
+            TextButton(onClick = onNavigateToSignIn) {
+                Text("Already have an account? Sign in")
             }
 
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(Modifier.height(8.dp))
 
-            //TextButton(onClick = onNavigateToSignIn) {
-                Text("Already have an account? Sign in")
-            //}
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-
-            uiState.errorMessage?.let { error ->
+            error?.let {
                 Text(
-                    text = error,
+                    text = it,
                     color = MaterialTheme.colorScheme.error,
                     style = MaterialTheme.typography.bodySmall
                 )
             }
         }
 
-        if (uiState.isLoading) {
-            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+        if (isLoading) {
+            CircularProgressIndicator(Modifier.align(Alignment.Center))
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ activityCompose = "1.10.1"
 turbine = "1.1.0"
 kotlinx-coroutines-test = "1.8.0"
 connectivity = "1.2.0"
+navigation = "2.7.7"
+hiltNavigationCompose = "1.2.0"
 
 
 
@@ -66,7 +68,8 @@ firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-fires
 kotlin-serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
 
 androidx-connectivity = { group = "androidx.connectivity", name = "connectivity-manager", version.ref = "connectivity" }
-
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
+androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version = "1.9.24" }


### PR DESCRIPTION
### Summary
This PR introduces app-wide navigation and cleans up the auth flow:

- Added `AppNavHost` with routes: Splash → SignIn/SignUp → Tasks
- Converted `SignInScreen` and `SignUpScreen` into presentational composables (no internal ViewModel)
- Added route wrappers (`SignInRoute`, `SignUpRoute`) injecting `AuthViewModel` via Hilt
- Fixed param mismatch (`onNavigateToSignIn`) in NavHost and SignUpRoute
- Hooked up `MainActivity` to render the NavHost

### Benefits
- Clear separation of concerns (UI vs logic)
- Hilt-friendly ViewModel injection
- Predictable navigation based on FirebaseAuth state

### How to test
1. Launch app → should briefly show Splash and then route:
   - If logged in → `Tasks`
   - If not logged in → `SignIn`
2. From SignIn → navigate to SignUp, create an account → lands on `Tasks`
3. Back from SignUp → returns to SignIn
