### PR TITLE
feat(sync): introduce offline ops queue (Room) for add/delete retries

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/data/task/src/main/java/com/fermer/task/di/RoomModule.kt
+++ b/data/task/src/main/java/com/fermer/task/di/RoomModule.kt
@@ -3,6 +3,7 @@ package com.fermer.task.di
 import android.content.Context
 import androidx.room.Room
 import com.fermer.task.firebase.FirebaseTaskDataSource
+import com.fermer.task.local.OfflineOpDao
 import com.fermer.task.local.RoomTaskDataSource
 import com.fermer.task.local.TaskDao
 import com.fermer.task.local.TaskDatabase
@@ -21,12 +22,9 @@ object TaskDataModule {
     @Provides @Singleton
     fun provideFirestore(): FirebaseFirestore = FirebaseFirestore.getInstance()
 
-    @Provides @Singleton
-    fun provideDatabase(@ApplicationContext context: Context): TaskDatabase =
-        Room.databaseBuilder(context, TaskDatabase::class.java, "task_db").build()
 
-    @Provides
-    fun provideTaskDao(db: TaskDatabase): TaskDao = db.taskDao()
+
+
 
     @Provides @Singleton
     fun provideFirebaseTaskDataSource(
@@ -37,4 +35,16 @@ object TaskDataModule {
     fun provideRoomTaskDataSource(
         dao: TaskDao
     ): RoomTaskDataSource = RoomTaskDataSource(dao)
+
+    @Provides @Singleton
+    fun provideTaskDatabase(@ApplicationContext context: Context): TaskDatabase =
+        Room.databaseBuilder(context, TaskDatabase::class.java, "task_db")
+            .fallbackToDestructiveMigration()
+            .build()
+
+    @Provides
+    fun provideTaskDao(db: TaskDatabase): TaskDao = db.taskDao()
+
+    @Provides
+    fun provideOfflineOpDao(db: TaskDatabase): OfflineOpDao = db.offlineOpDao()
 }

--- a/data/task/src/main/java/com/fermer/task/local/OfflineOpDao.kt
+++ b/data/task/src/main/java/com/fermer/task/local/OfflineOpDao.kt
@@ -1,0 +1,37 @@
+package com.fermer.task.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface OfflineOpDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun enqueue(op: OfflineOpEntity)
+
+    @Query("SELECT * FROM offline_ops WHERE status = :status ORDER BY createdAt ASC")
+    fun observeByStatus(status: OpStatus = OpStatus.PENDING): Flow<List<OfflineOpEntity>>
+
+    @Query("SELECT * FROM offline_ops WHERE status = :status ORDER BY createdAt ASC LIMIT 1")
+    suspend fun peekPending(status: OpStatus = OpStatus.PENDING): OfflineOpEntity?
+
+    @Update
+    suspend fun update(op: OfflineOpEntity)
+
+    @Query("UPDATE offline_ops SET status = :status WHERE id = :id")
+    suspend fun setStatus(id: Long, status: OpStatus)
+
+    @Query("UPDATE offline_ops SET retryCount = retryCount + 1 WHERE id = :id")
+    suspend fun incRetry(id: Long)
+
+    @Query("DELETE FROM offline_ops WHERE id = :id")
+    suspend fun deleteById(id: Long)
+
+    @Query("DELETE FROM offline_ops WHERE status = :status")
+    suspend fun clearByStatus(status: OpStatus = OpStatus.DONE)
+}
+

--- a/data/task/src/main/java/com/fermer/task/local/OfflineOpEntity.kt
+++ b/data/task/src/main/java/com/fermer/task/local/OfflineOpEntity.kt
@@ -1,0 +1,20 @@
+package com.fermer.task.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+
+@Entity(tableName = "offline_ops")
+data class OfflineOpEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0L,
+    val type: OpType,           // ADD or DELETE
+    val taskId: String,
+    val title: String?,
+    val isDone: Boolean?,
+    val createdAt: Long = System.currentTimeMillis(),
+    val retryCount: Int = 0,
+    val status: OpStatus = OpStatus.PENDING
+)
+
+enum class OpType { ADD, DELETE }
+enum class OpStatus { PENDING, SENDING, DONE, FAILED }

--- a/data/task/src/main/java/com/fermer/task/local/TaskDatabase.kt
+++ b/data/task/src/main/java/com/fermer/task/local/TaskDatabase.kt
@@ -4,7 +4,12 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 
 
-@Database(entities = [TaskEntity::class], version = 1)
+@Database(
+    entities = [TaskEntity::class, OfflineOpEntity::class],
+    version = 2,
+    exportSchema = false
+)
 abstract class TaskDatabase : RoomDatabase() {
     abstract fun taskDao(): TaskDao
+    abstract fun offlineOpDao(): OfflineOpDao
 }


### PR DESCRIPTION
### Summary
Adds the foundation for offline sync:
- `OfflineOpEntity` (type/status/payload/createdAt/retryCount)
- `OfflineOpDao` (enqueue/peek/update/clear)
- Database updated to include offline_ops (version bump)

Next steps (Day 3):
- Enqueue on Firebase write failure in repository
- Add `SyncWorker` (WorkManager) to drain the queue when online
- Remote → Local merge policy
