### PR TITLE
feat(sync): add enqueue-on-failure logic to TaskRepository for offline sync

### DIFF
--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,39 @@
+{
+  "project_info": {
+    "project_number": "812860580986",
+    "project_id": "todox-92c04",
+    "storage_bucket": "todox-92c04.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:812860580986:android:2c745c08095be94576c7c3",
+        "android_client_info": {
+          "package_name": "com.fermer.todox"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "812860580986-iv06njq7oc5ue4oun5a4c1o5oij2obnk.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCJi-X8gANUk7SKGRY1BMgq8lBh29yVUuQ"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "812860580986-iv06njq7oc5ue4oun5a4c1o5oij2obnk.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/java/com/fermer/todox/MainActivity.kt
+++ b/app/src/main/java/com/fermer/todox/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import com.fermer.task.presentation.TaskListRoute
 import com.fermer.todox.nav.AppNavHost
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/app/src/main/java/com/fermer/todox/nav/AppNavHost.kt
+++ b/app/src/main/java/com/fermer/todox/nav/AppNavHost.kt
@@ -9,6 +9,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.fermer.task.presentation.TaskListRoute
 import com.fermer.task.presentation.TaskScreen
 import com.google.firebase.auth.FirebaseAuth
 
@@ -63,7 +64,7 @@ fun AppNavHost(
 
 
         composable(Dest.Tasks.route) {
-            TaskScreen()
+            TaskListRoute()
         }
     }
 }

--- a/data/task/src/main/java/com/fermer/task/di/TaskRepositoryModule.kt
+++ b/data/task/src/main/java/com/fermer/task/di/TaskRepositoryModule.kt
@@ -1,20 +1,32 @@
 package com.fermer.task.di
 
 import com.fermer.task.domain.TaskRepository
+import com.fermer.task.local.OfflineOpDao
+import com.fermer.task.local.TaskDao
 import com.fermer.task.repository.TaskRepositoryImpl
+import com.google.firebase.firestore.FirebaseFirestore
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class TaskRepositoryModule {
 
-    @Binds
-    @Singleton
-    abstract fun bindTaskRepository(
-        impl: TaskRepositoryImpl
-    ): TaskRepository
+    @Provides
+    fun provideTaskRepository(
+        firestore: FirebaseFirestore,
+        taskDao: TaskDao,
+        offlineOpDao: OfflineOpDao,
+        @IoDispatcher ioDispatcher: CoroutineDispatcher
+    ): TaskRepository = TaskRepositoryImpl(
+        firestore,
+        taskDao,
+        offlineOpDao,
+        ioDispatcher
+    )
 }

--- a/data/task/src/main/java/com/fermer/task/local/Mapper.kt
+++ b/data/task/src/main/java/com/fermer/task/local/Mapper.kt
@@ -1,0 +1,16 @@
+package com.fermer.task.local
+
+import com.fermer.model.TaskModel
+
+
+internal fun TaskEntity.toDomain() = TaskModel(
+    id = id,
+    title = title,
+    isDone = isDone
+)
+
+internal fun TaskModel.toEntity() = TaskEntity(
+    id = if (id.isBlank()) java.util.UUID.randomUUID().toString() else id,
+    title = title,
+    isDone = isDone
+)

--- a/data/task/src/main/java/com/fermer/task/local/TaskDao.kt
+++ b/data/task/src/main/java/com/fermer/task/local/TaskDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import com.fermer.model.TaskModel
 import kotlinx.coroutines.flow.Flow
 
 

--- a/data/task/src/main/java/com/fermer/task/repository/TaskRepositoryImpl.kt
+++ b/data/task/src/main/java/com/fermer/task/repository/TaskRepositoryImpl.kt
@@ -4,25 +4,88 @@ package com.fermer.task.repository
 import com.fermer.model.TaskModel
 import com.fermer.task.domain.TaskRepository
 import com.fermer.task.firebase.FirebaseTaskDataSource
+import com.fermer.task.local.OfflineOpDao
+import com.fermer.task.local.OfflineOpEntity
+import com.fermer.task.local.OpStatus
+import com.fermer.task.local.OpType
 import com.fermer.task.local.RoomTaskDataSource
+import com.fermer.task.local.TaskDao
+import com.fermer.task.local.TaskEntity
+import com.fermer.task.local.toDomain
+import com.fermer.task.local.toEntity
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 
-class TaskRepositoryImpl @Inject constructor(
-    private val firebase: FirebaseTaskDataSource,
-    private val room: RoomTaskDataSource
+
+class TaskRepositoryImpl(
+    private val firestore: FirebaseFirestore,
+    private val taskDao: TaskDao,
+    private val offlineOpDao: OfflineOpDao,
+    private val io: CoroutineDispatcher
 ) : TaskRepository {
 
-    override fun getTasks(): Flow<List<TaskModel>> = room.getTasks()
+   
+    override fun getTasks(): Flow<List<TaskModel>> =
+        taskDao.getTasks().map { list -> list.map { it.toDomain() } }
 
-    override suspend fun addTask(task: TaskModel) {
-        room.addTask(task)
-        runCatching { firebase.addTask(task) }
+
+    override suspend fun addTask(task: TaskModel): Unit = withContext(io) {
+        val entity = task.toEntity()
+        try {
+
+            taskDao.insert(entity)
+
+
+            firestore.collection("tasks")
+                .document(entity.id)
+                .set(
+                    mapOf(
+                        "id" to entity.id,
+                        "title" to entity.title,
+                        "isDone" to entity.isDone
+                    )
+                )
+                .await()
+        } catch (e: Exception) {
+
+            offlineOpDao.enqueue(
+                OfflineOpEntity(
+                    type = OpType.ADD,
+                    taskId = entity.id,
+                    title = entity.title,
+                    isDone = entity.isDone,
+                    status = OpStatus.PENDING
+                )
+            )
+        }
     }
+    override suspend fun removeTask(taskId: String): Unit = withContext(io) {
+        try {
 
-    override suspend fun removeTask(id: String) {
-        room.removeTask(id)
-        runCatching { firebase.removeTask(id) }
+            taskDao.delete(taskId)
+
+
+            firestore.collection("tasks")
+                .document(taskId)
+                .delete()
+                .await()
+        } catch (e: Exception) {
+
+            offlineOpDao.enqueue(
+                OfflineOpEntity(
+                    type = OpType.DELETE,
+                    taskId = taskId,
+                    title = null,
+                    isDone = null,
+                    status = OpStatus.PENDING
+                )
+            )
+        }
     }
 }

--- a/feature/task/src/main/java/com/fermer/task/presentation/TaskListScreen.kt
+++ b/feature/task/src/main/java/com/fermer/task/presentation/TaskListScreen.kt
@@ -7,15 +7,18 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.fermer.model.TaskModel
 import com.fermer.task.presentation.components.TaskItem
+import kotlin.collections.List
 
 @Composable
 fun TaskListScreen(
-    taskList: List<TaskModel>,
+     taskList: List<TaskModel>,
     onAddTask: (String) -> Unit,
     onRemoveTask: (String) -> Unit
 ) {
+
     var showDialog by remember { mutableStateOf(false) }
     var newTaskTitle by remember { mutableStateOf("") }
 

--- a/feature/task/src/main/java/com/fermer/task/presentation/TaskViewModel.kt
+++ b/feature/task/src/main/java/com/fermer/task/presentation/TaskViewModel.kt
@@ -22,7 +22,7 @@ class TaskViewModel @Inject constructor(
 
     fun addTask(title: String) {
         viewModelScope.launch {
-            repository.addTask(TaskModel(title = title))
+            repository.addTask(TaskModel(id = "", title = title, isDone = false))
         }
     }
 


### PR DESCRIPTION
### Summary
Enhances `TaskRepositoryImpl` to handle offline scenarios:
- On Firebase `addTask` failure → enqueue `OpType.ADD` to Room queue
- On Firebase `deleteTask` failure → enqueue `OpType.DELETE` to Room queue
- Both operations still update local cache immediately (optimistic UI)

### Benefits
Prepares data layer for automatic retry (via WorkManager) when network is restored.

