### PR TITLE
feat(sync): introduce WorkManager SyncWorker and enqueue on network available

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -12,6 +12,7 @@
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
             <option value="$PROJECT_DIR$/core" />
+            <option value="$PROJECT_DIR$/core/common" />
             <option value="$PROJECT_DIR$/core/data" />
             <option value="$PROJECT_DIR$/core/designsystem" />
             <option value="$PROJECT_DIR$/core/domain" />
@@ -28,7 +29,6 @@
             <option value="$PROJECT_DIR$/feature/tasklist" />
           </set>
         </option>
-        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/data/task/build.gradle.kts
+++ b/data/task/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)
 
+
     // Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.firestore.ktx)
@@ -55,6 +56,10 @@ dependencies {
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
     kapt(libs.room.compiler)
+
+    implementation(libs.androidx.work)
+    implementation(libs.androidx.hilt.work)
+
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/data/task/src/main/java/com/fermer/task/sync/SyncScheduler.kt
+++ b/data/task/src/main/java/com/fermer/task/sync/SyncScheduler.kt
@@ -1,0 +1,28 @@
+package com.fermer.task.sync
+
+
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+
+object SyncScheduler {
+    private const val UNIQUE_NAME = "offline-sync"
+
+    fun enqueue(workManager: WorkManager) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        val request = OneTimeWorkRequestBuilder<SyncWorker>()
+            .setConstraints(constraints)
+            .build()
+
+        workManager.enqueueUniqueWork(
+            UNIQUE_NAME,
+            ExistingWorkPolicy.KEEP,
+            request
+        )
+    }
+}

--- a/data/task/src/main/java/com/fermer/task/sync/SyncWorker.kt
+++ b/data/task/src/main/java/com/fermer/task/sync/SyncWorker.kt
@@ -1,0 +1,55 @@
+package com.fermer.task.sync
+
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.fermer.task.local.OfflineOpDao
+import com.fermer.task.local.OpStatus
+import com.fermer.task.local.OpType
+import com.google.firebase.firestore.FirebaseFirestore
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.tasks.await
+
+@HiltWorker
+class SyncWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val offlineOpDao: OfflineOpDao,
+    private val firestore: FirebaseFirestore,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        while (true) {
+            val op = offlineOpDao.peekPending(OpStatus.PENDING) ?: break
+            try {
+                when (op.type) {
+                    OpType.ADD -> {
+                        val map = mapOf(
+                            "id" to op.taskId,
+                            "title" to (op.title ?: ""),
+                            "isDone" to (op.isDone ?: false)
+                        )
+                        firestore.collection("tasks")
+                            .document(op.taskId)
+                            .set(map)
+                            .await()
+                    }
+                    OpType.DELETE -> {
+                        firestore.collection("tasks")
+                            .document(op.taskId)
+                            .delete()
+                            .await()
+                    }
+                }
+                offlineOpDao.setStatus(op.id, OpStatus.DONE)
+            } catch (e: Exception) {
+                offlineOpDao.incRetry(op.id)
+                return Result.retry()
+            }
+        }
+        return Result.success()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ kotlinx-coroutines-test = "1.8.0"
 connectivity = "1.2.0"
 navigation = "2.7.7"
 hiltNavigationCompose = "1.2.0"
+work = "2.9.0"
+hiltWork = "1.2.0"
 
 
 
@@ -70,6 +72,10 @@ kotlin-serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serial
 androidx-connectivity = { group = "androidx.connectivity", name = "connectivity-manager", version.ref = "connectivity" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+
+androidx-work = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWork" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version = "1.9.24" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,3 +34,4 @@ include(":feature:search")
 include(":feature:setting")
 
 include(":data:task")
+include(":core:common")


### PR DESCRIPTION
### Summary
Adds an offline sync mechanism using WorkManager:
- `SyncWorker` (Hilt) processes queued offline ops (ADD/DELETE) to Firestore
- `SyncScheduler` enqueues unique one-time work with `NetworkType.CONNECTED`
- Hook point to trigger sync when connectivity becomes available

