### PR TITLE
🔄 Sync System: Enable offline-to-online task sync via WorkManager

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
 
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)
+    implementation(libs.androidx.hilt.work)
 
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.hilt.navigation.compose)

--- a/app/src/main/java/com/fermer/todox/Application.kt
+++ b/app/src/main/java/com/fermer/todox/Application.kt
@@ -1,7 +1,19 @@
 package com.fermer.todox
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
-class TodoXApplication : Application()
+class Application : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+
+}

--- a/app/src/main/java/com/fermer/todox/nav/AppNavHost.kt
+++ b/app/src/main/java/com/fermer/todox/nav/AppNavHost.kt
@@ -1,15 +1,19 @@
 package com.fermer.todox.nav
 
+import android.content.Context
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.work.WorkManager
 import com.fermer.task.presentation.TaskListRoute
+import com.fermer.task.sync.SyncScheduler
 import com.google.firebase.auth.FirebaseAuth
 
 @Composable
@@ -26,7 +30,8 @@ fun AppNavHost(
                     if (isLoggedIn)
                         Dest.Tasks.route
                     else
-                        Dest.SignIn.route)
+                        Dest.SignIn.route
+                )
                 {
                     popUpTo(Dest.Splash.route) { inclusive = true }
                     launchSingleTop = true
@@ -71,5 +76,6 @@ fun AppNavHost(
 @Composable
 private fun BoxedLoading() {
     Scaffold { padding ->
-        CircularProgressIndicator(modifier = androidx.compose.ui.Modifier.padding(padding)) }
+        CircularProgressIndicator(modifier = androidx.compose.ui.Modifier.padding(padding))
+    }
 }

--- a/app/src/main/java/com/fermer/todox/nav/AuthRoutes.kt
+++ b/app/src/main/java/com/fermer/todox/nav/AuthRoutes.kt
@@ -18,7 +18,8 @@ fun SignInRoute(
     val state by viewModel.uiState.collectAsState()
 
     LaunchedEffect(state.isSuccess) {
-        if (state.isSuccess) onAuthSuccess()
+        if (state.isSuccess)
+            onAuthSuccess()
     }
 
     SignInScreen(

--- a/data/task/build.gradle.kts
+++ b/data/task/build.gradle.kts
@@ -46,9 +46,10 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    implementation(libs.androidx.work)
     implementation(libs.androidx.hilt.work)
+    implementation(libs.androidx.work)
     kapt(libs.hilt.android.compiler)
+
 
 
 

--- a/data/task/src/main/java/com/fermer/task/di/WorkerBindingModule.kt
+++ b/data/task/src/main/java/com/fermer/task/di/WorkerBindingModule.kt
@@ -1,0 +1,22 @@
+package com.fermer.task.di
+
+import com.fermer.task.sync.ChildWorkerFactory
+import com.fermer.task.sync.SyncWorker
+import com.fermer.task.sync.SyncWorkerFactory
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class WorkerBindingModule {
+
+    @Binds
+    @IntoMap
+    @WorkerKey(SyncWorker::class)
+    abstract fun bindSyncWorker(factory: SyncWorkerFactory): ChildWorkerFactory
+}
+

--- a/data/task/src/main/java/com/fermer/task/di/WorkerKey.kt
+++ b/data/task/src/main/java/com/fermer/task/di/WorkerKey.kt
@@ -1,0 +1,12 @@
+package com.fermer.task.di
+
+
+import androidx.work.ListenableWorker
+import dagger.MapKey
+import kotlin.reflect.KClass
+
+@MapKey
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class WorkerKey(val value: KClass<out ListenableWorker>)
+

--- a/data/task/src/main/java/com/fermer/task/sync/ChildWorkerFactory.kt
+++ b/data/task/src/main/java/com/fermer/task/sync/ChildWorkerFactory.kt
@@ -1,0 +1,9 @@
+package com.fermer.task.sync
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+
+interface ChildWorkerFactory {
+    fun create(appContext: Context, params: WorkerParameters): ListenableWorker
+}

--- a/data/task/src/main/java/com/fermer/task/sync/SyncWorker.kt
+++ b/data/task/src/main/java/com/fermer/task/sync/SyncWorker.kt
@@ -18,7 +18,7 @@ class SyncWorker @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted params: WorkerParameters,
     private val offlineOpDao: OfflineOpDao,
-    private val firestore: FirebaseFirestore,
+    private val firestore: FirebaseFirestore
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun doWork(): Result {

--- a/data/task/src/main/java/com/fermer/task/sync/SyncWorkerFactory.kt
+++ b/data/task/src/main/java/com/fermer/task/sync/SyncWorkerFactory.kt
@@ -1,0 +1,3 @@
+package com.fermer.task.sync
+
+interface SyncWorkerFactory : ChildWorkerFactory

--- a/feature/task/build.gradle.kts
+++ b/feature/task/build.gradle.kts
@@ -51,16 +51,19 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.lifecycle.viewmodel)
     implementation(libs.androidx.foundation.layout)
-    implementation(libs.hilt.android)
-    kapt(libs.hilt.android.compiler)
-    implementation(libs.hilt.navigation.compose)
+
+
 
     testImplementation(libs.kotlin.test)
     testImplementation(libs.coroutines.test)
     testImplementation(libs.turbine)
-
-    implementation(libs.androidx.work)
+    
+    // Hilt
+    implementation(libs.hilt.android)
     implementation(libs.androidx.hilt.work)
+    implementation(libs.androidx.work)
+    kapt(libs.hilt.android.compiler)
+    implementation(libs.hilt.navigation.compose)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/feature/task/src/main/java/com/fermer/task/presentation/TaskListRoute.kt
+++ b/feature/task/src/main/java/com/fermer/task/presentation/TaskListRoute.kt
@@ -1,12 +1,22 @@
 package com.fermer.task.presentation
 
+import android.content.Context
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.work.WorkManager
+import com.fermer.task.sync.SyncScheduler
 
 @Composable
 fun TaskListRoute(viewModel: TaskListViewModel = hiltViewModel()) {
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        scheduleSync(context = context)
+    }
 
     val tasks by viewModel.tasks.collectAsState()
 
@@ -16,4 +26,8 @@ fun TaskListRoute(viewModel: TaskListViewModel = hiltViewModel()) {
         onRemoveTask = { viewModel.removeTask(it) },
         onToggleCheck = { viewModel.updateTask(it) }
     )
+}
+
+fun scheduleSync(context: Context) {
+    SyncScheduler.enqueue(WorkManager.getInstance(context))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,9 +13,12 @@ turbine = "1.1.0"
 kotlinx-coroutines-test = "1.8.0"
 connectivity = "1.2.0"
 navigation = "2.7.7"
-hiltNavigationCompose = "1.2.0"
-work = "2.9.0"
+
+
 hiltWork = "1.2.0"
+work = "2.10.3"
+hiltNavigationCompose = "1.2.0"
+
 
 
 
@@ -28,8 +31,7 @@ kotlin-test = "1.9.0"
 room = "2.6.1"
 firebase-bom = "34.0.0"
 firebase-firestore = "24.11.0"
-hilt = "2.48"
-hilt-compiler = "2.48"
+
 serialization = "1.6.0"
 
 
@@ -63,6 +65,9 @@ androidx-foundation-layout = { group = "androidx.compose.foundation", name = "fo
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version = "2.48" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version = "2.48" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version = "1.2.0" }
+androidx-work = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWork" }
+
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
@@ -73,8 +78,7 @@ androidx-connectivity = { group = "androidx.connectivity", name = "connectivity-
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 
-androidx-work = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
-androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWork" }
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## What’s Done

This PR adds support for background syncing of offline tasks to Firebase when network connectivity is regained. Key additions include:

- `SyncWorker`: a Hilt-enabled background worker that uploads pending tasks from local DB to Firebase.
- `SyncScheduler`: schedules the worker using `WorkManager`.
- Integration in `TaskListRoute` to trigger sync using `LaunchedEffect`.
- Added custom `@WorkerKey` annotation for Dagger multibinding.
- Hilt modules configured to support worker injection properly.

## Why

This improves the offline-first architecture by ensuring:
- User data is not lost when offline
- Tasks are synced seamlessly when network is available

## Notes

- We may want to later hook the sync trigger to connectivity status changes for efficiency.
- Testing required for long queues and edge network cases.
